### PR TITLE
Use write-lock library

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/dominictarr/atomic-file.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "read-write-lock": "^1.0.6"
+  },
   "devDependencies": {
     "tape": "^4.6.0"
   },


### PR DESCRIPTION
Makes the code simpler by delegating the write-locking pattern to [another simple library](https://github.com/TehShrike/read-write-lock/).

This pull request doesn't change the existing behavior, but if you wanted to prevent reads from happening while a write was happening, you could change the `get` method to use

``` js
locker.readLock(function(unlock) {
  fs.readFile(filename, 'utf8', function (err, _value) {
    unlock()
    if(err) return cb(err)
    cb(null, value = JSON.parse(_value))
  })
})
```

Feel free to ignore/close this pull request without hurting my feelings, I just saw some boilerplate locking code and felt compelled to refactor it :-)
